### PR TITLE
1.19.2 Update for Create 0.5g

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ apply plugin: 'eclipse'
 apply plugin: 'maven-publish'
 
 
-version = '3.1.2'
+version = "${mod_version}"
 group = 'com.hollingsworth.ars_creo' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = "ars_creo-${mc_version}"
 

--- a/build.gradle
+++ b/build.gradle
@@ -31,11 +31,11 @@ apply plugin: 'maven-publish'
 
 version = '3.1.2'
 group = 'com.hollingsworth.ars_creo' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
-archivesBaseName = 'ars_creo-1.19.2'
+archivesBaseName = "ars_creo-${mc_version}"
 
 java.toolchain.languageVersion = JavaLanguageVersion.of(17)
 minecraft {
-    mappings channel: 'parchment', version: '2022.08.14-1.19.2'
+    mappings channel: 'parchment', version: "${parchment_version}-${mc_version}"
     // makeObfSourceJar = false // an Srg named sources jar is made by default. uncomment this to disable.
 
     // accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg')
@@ -144,22 +144,22 @@ repositories {
 }
 dependencies {
 
-    minecraft "net.minecraftforge:forge:1.19.2-${forge_version}"
-    implementation fg.deobf("com.simibubi.create:create-1.19.2:0.5.0.f-15:slim"){ transitive = false }
-    implementation fg.deobf("com.jozufozu.flywheel:flywheel-forge-1.19.2:0.6.7-9")
-    implementation fg.deobf("com.tterrag.registrate:Registrate:MC1.19-1.1.5")
-    implementation fg.deobf("com.hollingsworth.ars_nouveau:ars_nouveau-1.19.2:${ars_version}")
+    minecraft "net.minecraftforge:forge:${mc_version}-${forge_version}"
+    implementation fg.deobf("com.simibubi.create:create-${mc_version}:${create_version}:slim"){ transitive = false }
+    implementation fg.deobf("com.jozufozu.flywheel:flywheel-forge-${mc_version}:${flywheel_version}")
+    implementation fg.deobf("com.tterrag.registrate:Registrate:${registrate_version}")
+    implementation fg.deobf("com.hollingsworth.ars_nouveau:ars_nouveau-${mc_version}:${ars_version}")
 
-    implementation fg.deobf("vazkii.patchouli:Patchouli:${patchouli_version}")
-    compileOnly fg.deobf("mezz.jei:jei-1.19.2-common-api:${jei_version}")
-    compileOnly fg.deobf("mezz.jei:jei-1.19.2-forge-api:${jei_version}")
+    implementation fg.deobf("vazkii.patchouli:Patchouli:${mc_version}-${patchouli_version}")
+    compileOnly fg.deobf("mezz.jei:jei-${mc_version}-common-api:${jei_version}")
+    compileOnly fg.deobf("mezz.jei:jei-${mc_version}-forge-api:${jei_version}")
     // at runtime, use the full JEI
-    runtimeOnly fg.deobf("mezz.jei:jei-1.19.2-common:${jei_version}")
-    runtimeOnly fg.deobf("mezz.jei:jei-1.19.2-forge:${jei_version}")
+    runtimeOnly fg.deobf("mezz.jei:jei-${mc_version}-common:${jei_version}")
+    runtimeOnly fg.deobf("mezz.jei:jei-${mc_version}-forge:${jei_version}")
 
     implementation fg.deobf("top.theillusivec4.curios:curios-forge:${mc_version}-${curios_version}")
 
-    implementation fg.deobf("com.github.glitchfiend:TerraBlender-forge:${mc_version}-2.0.0.120")
+    implementation fg.deobf("com.github.glitchfiend:TerraBlender-forge:${terrablender_version}")
 
     annotationProcessor "org.spongepowered:mixin:0.8.5:processor"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,9 +2,15 @@
 # This is required to provide enough memory for the Minecraft decompilation process.
 org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
-mc_version = 1.19
+
+mc_version = 1.19.2
+forge_version = 43.1.52
+parchment_version = 2022.08.14
+curios_version = 5.1.1.0
+patchouli_version = 77
+ars_version = 3.5.1.251
+registrate_version = MC1.19-1.1.5
+create_version = 0.5.0.g-19
+flywheel_version = 0.6.8-13
 jei_version = 11.2.0.246
-forge_version = 43.1.33
-curios_version = 5.1.0.4
-patchouli_version = 1.19.2-77
-ars_version = 3.4.7.245
+terrablender_version = 1.19-2.0.0.120

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,8 @@
 org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 
+mod_version = 3.1.2
+
 mc_version = 1.19.2
 forge_version = 43.1.52
 parchment_version = 2022.08.14

--- a/src/main/java/com/hollingsworth/ars_creo/contraption/ITurretBehavior.java
+++ b/src/main/java/com/hollingsworth/ars_creo/contraption/ITurretBehavior.java
@@ -45,8 +45,6 @@ public interface ITurretBehavior {
         EntitySpellResolver resolver = new EntitySpellResolver((new SpellContext(world, spell, fakePlayer, new ContraptionCaster(context.contraption.entity))));
         if(!ContraptionUtils.removeSourceFromContraption(context, spell.getDiscountedCost(), pos)) {
             boolean hasNearby = SourceUtil.hasSourceNearby(pos, world, 6, spell.getDiscountedCost());
-            int size = SourceManager.INSTANCE.getSetForLevel(world).size();
-            System.out.println(size);
             if(!hasNearby || SourceUtil.takeSourceWithParticles(pos, world, 6, spell.getDiscountedCost()) == null){
                 return;
             }

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -40,7 +40,7 @@ Adds compatibility between Ars Nouveau and Create
     # Does this dependency have to exist - if not, ordering below must be specified
     mandatory=true #mandatory
     # The version range of the dependency
-    versionRange="[38.1.0,)" #mandatory
+    versionRange="[43.1.52,)" #mandatory
     # An ordering relationship for the dependency - BEFORE or AFTER required if the relationship is not mandatory
     ordering="NONE"
     # Side this dependency is applied on - BOTH, CLIENT or SERVER
@@ -56,19 +56,19 @@ Adds compatibility between Ars Nouveau and Create
 [[dependencies.ars_creo]]
     modId="curios"
     mandatory=true
-    versionRange="[1.18.1-5.0.3.0,)"
+    versionRange="[1.19.2-5.1.1.0,)"
     ordering="AFTER"
     side="BOTH"
 
 [[dependencies.ars_creo]]
     modId="ars_nouveau"
     mandatory=true
-    versionRange="[3.4.3,)"
+    versionRange="[3.5.1,)"
     ordering="AFTER"
     side="BOTH"
 [[dependencies.ars_creo]]
     modId="create"
     mandatory=true
-    versionRange="[0.5,)"
+    versionRange="[0.5.0g,)"
     ordering="AFTER"
     side="BOTH"


### PR DESCRIPTION
Hi there,
I was playing with this mod and it's dependencies on the latest version until I updated to Create 0.5g on 1.19.2 when that released. After this, turrets on moving contraptions would cause a crash whenever they tried to play the sound of that spell, by updating the dependencies in gradle this has been fixed for my world at least.
I formatted the gradle.properties and build.gradle for easy future updating and matched the forge version to the Ars Nouveau and Create version. I also removed a log message that spammed console whenever a turret was using source on a contraption.
Thanks for the great compatibility mod.