### PR TITLE
Optimized starbuncle wheel, fixed starbuncle wheel item rendering

### DIFF
--- a/src/main/java/com/hollingsworth/ars_creo/ArsCreo.java
+++ b/src/main/java/com/hollingsworth/ars_creo/ArsCreo.java
@@ -1,7 +1,5 @@
 package com.hollingsworth.ars_creo;
 
-
-import com.hollingsworth.ars_creo.client.render.ClientHandler;
 import com.hollingsworth.ars_creo.common.PotionTank;
 import com.hollingsworth.ars_creo.common.registry.CreativeTabRegistry;
 import com.hollingsworth.ars_creo.common.registry.ModBlockRegistry;
@@ -13,10 +11,8 @@ import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceLocation;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.ModContainer;
-import net.neoforged.fml.ModLoadingContext;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.fml.config.ModConfig;
-import net.neoforged.fml.event.lifecycle.FMLClientSetupEvent;
 import net.neoforged.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.neoforged.neoforge.capabilities.Capabilities;
 import net.neoforged.neoforge.capabilities.RegisterCapabilitiesEvent;
@@ -25,16 +21,13 @@ import net.neoforged.neoforge.registries.RegisterEvent;
 
 // The value here should match an entry in the META-INF/mods.toml file
 @Mod(ArsCreo.MODID)
-public class ArsCreo
-{
-
+public class ArsCreo {
     public static final String MODID = "ars_creo";
 
     public ArsCreo(IEventBus modBus, ModContainer modContainer) {
         NeoForge.EVENT_BUS.addListener(ArsNouveauRegistry::registerDocumentation);
         modContainer.registerConfig(ModConfig.Type.COMMON, CreoConfig.SERVER_CONFIG);
         modBus.addListener(ACNetworking::register);
-        modBus.addListener(this::clientSetup);
         modBus.addListener(ArsCreo::registerEvents);
         modBus.addListener(ArsCreo::registerCapability);
         modBus.addListener(ArsCreo::commonSetup);
@@ -50,9 +43,7 @@ public class ArsCreo
     }
 
     public static void registerEvents(RegisterEvent event) {
-        event.register(Registries.ITEM, helper ->{
-            ModBlockRegistry.onBlockItemsRegistry();
-        });
+        event.register(Registries.ITEM, helper -> ModBlockRegistry.onBlockItemsRegistry());
     }
 
     public static void commonSetup(FMLCommonSetupEvent event) {
@@ -61,16 +52,11 @@ public class ArsCreo
         CreateCompat.setupDisplayBehaviors();
     }
 
-
     public static void registerCapability(RegisterCapabilitiesEvent event) {
         event.registerBlockEntity(Capabilities.FluidHandler.BLOCK, BlockRegistry.POTION_JAR_TYPE.get(), (tile, ctx) -> new PotionTank(tile));
     }
 
-
     public static ResourceLocation prefix(String path){
         return ResourceLocation.fromNamespaceAndPath(MODID, path);
-    }
-    public void clientSetup(final FMLClientSetupEvent event) {
-        ModLoadingContext.get().getActiveContainer().getEventBus().addListener(ClientHandler::init);
     }
 }

--- a/src/main/java/com/hollingsworth/ars_creo/client/render/ClientHandler.java
+++ b/src/main/java/com/hollingsworth/ars_creo/client/render/ClientHandler.java
@@ -2,22 +2,58 @@ package com.hollingsworth.ars_creo.client.render;
 
 import com.hollingsworth.ars_creo.ArsCreo;
 import com.hollingsworth.ars_creo.common.registry.ModBlockRegistry;
-import net.minecraft.client.renderer.ItemBlockRenderTypes;
-import net.minecraft.client.renderer.RenderType;
+import com.hollingsworth.arsnouveau.common.items.AnimBlockItem;
+import net.minecraft.client.renderer.BlockEntityWithoutLevelRenderer;
+import net.minecraft.resources.ResourceLocation;
 import net.neoforged.api.distmarker.Dist;
-import net.neoforged.bus.api.SubscribeEvent;
-import net.neoforged.fml.common.EventBusSubscriber;
-import net.neoforged.fml.event.lifecycle.FMLClientSetupEvent;
+import net.neoforged.bus.api.IEventBus;
+import net.neoforged.fml.common.Mod;
 import net.neoforged.neoforge.client.event.EntityRenderersEvent;
+import net.neoforged.neoforge.client.extensions.common.IClientItemExtensions;
+import net.neoforged.neoforge.client.extensions.common.RegisterClientExtensionsEvent;
+import org.jetbrains.annotations.NotNull;
+import software.bernie.geckolib.animation.AnimationState;
+import software.bernie.geckolib.model.GeoModel;
+import software.bernie.geckolib.renderer.GeoItemRenderer;
 
-@EventBusSubscriber(value = Dist.CLIENT, modid = ArsCreo.MODID, bus = EventBusSubscriber.Bus.MOD)
+@Mod(value = ArsCreo.MODID, dist = Dist.CLIENT)
 public class ClientHandler {
-    @SubscribeEvent
-    public static void init(final FMLClientSetupEvent evt) {
-        ItemBlockRenderTypes.setRenderLayer(ModBlockRegistry.STARBY_WHEEL.get(), RenderType.cutout());
+    public ClientHandler(IEventBus bus) {
+        bus.addListener(ClientHandler::registerRenderers);
+        bus.addListener(ClientHandler::registerClientExtensions);
     }
-    @SubscribeEvent
-    public static void registerRenderers(final EntityRenderersEvent.RegisterRenderers event){
+
+    public static void registerRenderers(EntityRenderersEvent.RegisterRenderers event) {
         event.registerBlockEntityRenderer(ModBlockRegistry.STARBY_TILE.get(), StarbuncleWheelRenderer::new);
+    }
+
+    public static void registerClientExtensions(RegisterClientExtensionsEvent event) {
+        event.registerItem(new IClientItemExtensions() {
+            @Override
+            public @NotNull BlockEntityWithoutLevelRenderer getCustomRenderer() {
+                return new GeoItemRenderer<AnimBlockItem>(new GeoModel<>() {
+                    @Override
+                    public void setCustomAnimations(AnimBlockItem item, long uniqueID, AnimationState<AnimBlockItem> customPredicate) {
+                        super.setCustomAnimations(item, uniqueID, customPredicate);
+                        getAnimationProcessor().getBone("wheel").setRotY(0);
+                    }
+
+                    @Override
+                    public ResourceLocation getModelResource(AnimBlockItem animatable) {
+                        return StarbuncleWheelModel.model;
+                    }
+
+                    @Override
+                    public ResourceLocation getTextureResource(AnimBlockItem animatable) {
+                        return StarbuncleWheelModel.texture;
+                    }
+
+                    @Override
+                    public ResourceLocation getAnimationResource(AnimBlockItem animatable) {
+                        return StarbuncleWheelModel.animations;
+                    }
+                });
+            }
+        }, ModBlockRegistry.STARBY_WHEEL_ITEM);
     }
 }

--- a/src/main/java/com/hollingsworth/ars_creo/client/render/StarbuncleWheelModel.java
+++ b/src/main/java/com/hollingsworth/ars_creo/client/render/StarbuncleWheelModel.java
@@ -3,45 +3,28 @@ package com.hollingsworth.ars_creo.client.render;
 import com.hollingsworth.ars_creo.ArsCreo;
 import com.hollingsworth.ars_creo.common.block.StarbuncleWheelBlock;
 import com.hollingsworth.ars_creo.common.block.StarbuncleWheelTile;
-import com.hollingsworth.ars_creo.common.registry.ModBlockRegistry;
-import com.simibubi.create.content.kinetics.base.KineticBlockEntity;
-import com.simibubi.create.content.kinetics.simpleRelays.ICogWheel;
 import net.createmod.catnip.animation.AnimationTickHolder;
-import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.resources.ResourceLocation;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.api.distmarker.OnlyIn;
 import software.bernie.geckolib.animation.AnimationState;
 import software.bernie.geckolib.cache.object.GeoBone;
 import software.bernie.geckolib.model.GeoModel;
 
+@OnlyIn(Dist.CLIENT)
 public class StarbuncleWheelModel extends GeoModel<StarbuncleWheelTile> {
-
     @Override
     public void setCustomAnimations(StarbuncleWheelTile entity, long uniqueID, AnimationState<StarbuncleWheelTile> customPredicate) {
         super.setCustomAnimations(entity, uniqueID, customPredicate);
-        GeoBone head = this.getAnimationProcessor().getBone("wheel");
+        GeoBone wheel = this.getAnimationProcessor().getBone("wheel");
         Direction facing = entity.getBlockState().getValue(StarbuncleWheelBlock.FACING);
-        float angle = getAngleForTe(entity, entity.getBlockPos(), ModBlockRegistry.STARBY_WHEEL.get().getRotationAxis(entity.getBlockState()));
-        if(facing ==  Direction.SOUTH || facing == Direction.EAST) {
+        float angle = ((AnimationTickHolder.getRenderTime(entity.getLevel()) * entity.getSpeed() * .3f) % 360) / 180 * (float) Math.PI;
+        if (facing == Direction.SOUTH || facing == Direction.EAST)
             angle = -angle;
-        }
-        head.setRotY(angle);
+        wheel.setRotY(angle);
     }
 
-    public static float getAngleForTe(KineticBlockEntity te, final BlockPos pos, Direction.Axis axis) {
-        float time = AnimationTickHolder.getRenderTime(te.getLevel());
-        float offset = getRotationOffsetForPosition(te, pos, axis);
-        return ((time * te.getSpeed() * 3f / 10 + offset) % 360) / 180 * (float) Math.PI;
-    }
-    protected static float getRotationOffsetForPosition(KineticBlockEntity te, final BlockPos pos, final Direction.Axis axis) {
-        float offset = ICogWheel.isLargeCog(te.getBlockState()) ? 11.25f : 0;
-        double d = (((axis == Direction.Axis.X) ? 0 : pos.getX()) + ((axis == Direction.Axis.Y) ? 0 : pos.getY())
-                + ((axis == Direction.Axis.Z) ? 0 : pos.getZ())) % 2;
-        if (d == 0) {
-            offset = 22.5f;
-        }
-        return offset;
-    }
     static final ResourceLocation model = ResourceLocation.fromNamespaceAndPath(ArsCreo.MODID, "geo/starbuncle_wheel.geo.json");
     static final ResourceLocation texture = ResourceLocation.fromNamespaceAndPath(ArsCreo.MODID, "textures/block/starbuncle_wheel.png");
     static final ResourceLocation animations = ResourceLocation.fromNamespaceAndPath(ArsCreo.MODID, "animations/starbuncle_wheel_animation.json");

--- a/src/main/java/com/hollingsworth/ars_creo/client/render/StarbuncleWheelRenderer.java
+++ b/src/main/java/com/hollingsworth/ars_creo/client/render/StarbuncleWheelRenderer.java
@@ -2,7 +2,6 @@ package com.hollingsworth.ars_creo.client.render;
 
 import com.hollingsworth.ars_creo.common.block.StarbuncleWheelBlock;
 import com.hollingsworth.ars_creo.common.block.StarbuncleWheelTile;
-import com.hollingsworth.arsnouveau.client.renderer.item.GenericItemBlockRenderer;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 import com.mojang.math.Axis;
@@ -10,14 +9,16 @@ import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
 import net.minecraft.core.Direction;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.api.distmarker.OnlyIn;
 import software.bernie.geckolib.cache.object.BakedGeoModel;
 import software.bernie.geckolib.renderer.GeoBlockRenderer;
 
-
+@OnlyIn(Dist.CLIENT)
 public class StarbuncleWheelRenderer extends GeoBlockRenderer<StarbuncleWheelTile> {
     public static StarbuncleWheelModel wheelModel = new StarbuncleWheelModel();
 
-    public StarbuncleWheelRenderer(BlockEntityRendererProvider.Context renderManager) {
+    public StarbuncleWheelRenderer(BlockEntityRendererProvider.Context ignored) {
         super(wheelModel);
     }
 
@@ -25,24 +26,9 @@ public class StarbuncleWheelRenderer extends GeoBlockRenderer<StarbuncleWheelTil
     public void actuallyRender(PoseStack stack, StarbuncleWheelTile animatable, BakedGeoModel model, RenderType renderType, MultiBufferSource bufferSource, VertexConsumer buffer, boolean isReRender, float partialTick, int packedLight, int packedOverlay, int colour) {
         Direction facing = animatable.getBlockState().getValue(StarbuncleWheelBlock.FACING);
         stack.pushPose();
-        if(facing == Direction.WEST){
+        if (facing != Direction.UP && facing != Direction.DOWN)
             stack.mulPose(Axis.YP.rotationDegrees(-90));
-        }
-        if(facing == Direction.EAST) {
-            stack.mulPose(Axis.YP.rotationDegrees(-90));
-        }
-        if(facing == Direction.SOUTH){
-            stack.mulPose(Axis.YP.rotationDegrees(-90));
-        }
-        if(facing == Direction.NORTH) {
-            stack.mulPose(Axis.YP.rotationDegrees(-90));
-        }
         super.actuallyRender(stack, animatable, model, renderType, bufferSource, buffer, isReRender, partialTick, packedLight, packedOverlay, colour);
         stack.popPose();
     }
-
-    public static GenericItemBlockRenderer getISTER(){
-        return new GenericItemBlockRenderer(new StarbuncleWheelModel());
-    }
-
 }

--- a/src/main/java/com/hollingsworth/ars_creo/common/block/StarbuncleWheelBlock.java
+++ b/src/main/java/com/hollingsworth/ars_creo/common/block/StarbuncleWheelBlock.java
@@ -15,10 +15,11 @@ import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.RenderShape;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
+import org.jetbrains.annotations.NotNull;
 
 public class StarbuncleWheelBlock extends DirectionalKineticBlock implements IBE<StarbuncleWheelTile> {
-    public StarbuncleWheelBlock(Properties p_i48440_1_) {
-        super(p_i48440_1_);
+    public StarbuncleWheelBlock(Properties properties) {
+        super(properties);
         this.registerDefaultState(this.stateDefinition.any().setValue(FACING, Direction.NORTH));
     }
 
@@ -31,29 +32,23 @@ public class StarbuncleWheelBlock extends DirectionalKineticBlock implements IBE
         Player player = context.getPlayer();
 
         BlockState placedOn = world.getBlockState(pos.relative(face.getOpposite()));
-        if(placedOn.is(ModBlockRegistry.STARBY_WHEEL.get())){
+        if (placedOn.is(ModBlockRegistry.STARBY_WHEEL.get()))
             return defaultBlockState().setValue(FACING, placedOn.getValue(FACING));
-        }
 
-        Direction facing = face;
         boolean sneaking = player != null && player.isShiftKeyDown();
-        facing = horizontalFacing;
 
-        return defaultBlockState().setValue(FACING, sneaking ? facing.getOpposite() : facing);
+        return defaultBlockState().setValue(FACING, sneaking ? horizontalFacing.getOpposite() : horizontalFacing);
     }
 
     private void updateWheelSpeed(LevelAccessor world, BlockPos pos) {
+        withBlockEntityDo(world, pos, StarbuncleWheelTile::findGoldBlock);
         withBlockEntityDo(world, pos, StarbuncleWheelTile::updateGeneratedRotation);
-        withBlockEntityDo(world, pos, (te) -> te.setChanged());
-    }
-
-    public void updateAllSides(BlockState state, Level worldIn, BlockPos pos) {
-        updateWheelSpeed(worldIn, pos);
+        withBlockEntityDo(world, pos, StarbuncleWheelTile::setChanged);
     }
 
     @Override
-    public BlockState updateShape(BlockState stateIn, Direction facing, BlockState facingState, LevelAccessor worldIn,
-                                  BlockPos currentPos, BlockPos facingPos) {
+    public @NotNull BlockState updateShape(@NotNull BlockState stateIn, @NotNull Direction facing, @NotNull BlockState facingState, @NotNull LevelAccessor worldIn,
+                                           @NotNull BlockPos currentPos, @NotNull BlockPos facingPos) {
         if (worldIn instanceof WrappedLevel)
             return stateIn;
 
@@ -64,12 +59,10 @@ public class StarbuncleWheelBlock extends DirectionalKineticBlock implements IBE
     @Override
     public void onPlace(BlockState state, Level worldIn, BlockPos pos, BlockState oldState, boolean isMoving) {
         super.onPlace(state, worldIn, pos, oldState, isMoving);
-        updateAllSides(state, worldIn, pos);
     }
 
-
     @Override
-    public RenderShape getRenderShape(BlockState p_149645_1_) {
+    public @NotNull RenderShape getRenderShape(@NotNull BlockState state) {
         return RenderShape.ENTITYBLOCK_ANIMATED;
     }
 

--- a/src/main/java/com/hollingsworth/ars_creo/common/block/StarbuncleWheelTile.java
+++ b/src/main/java/com/hollingsworth/ars_creo/common/block/StarbuncleWheelTile.java
@@ -3,7 +3,6 @@ package com.hollingsworth.ars_creo.common.block;
 import com.hollingsworth.ars_creo.CreoConfig;
 import com.hollingsworth.ars_creo.common.registry.ModBlockRegistry;
 import com.simibubi.create.content.kinetics.base.GeneratingKineticBlockEntity;
-import com.simibubi.create.content.kinetics.crank.HandCrankBlock;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.level.block.state.BlockState;
@@ -16,31 +15,32 @@ import software.bernie.geckolib.animation.PlayState;
 import software.bernie.geckolib.animation.RawAnimation;
 import software.bernie.geckolib.util.GeckoLibUtil;
 
-
 public class StarbuncleWheelTile extends GeneratingKineticBlockEntity implements GeoBlockEntity {
+    @SuppressWarnings("all")
+    private AnimatableInstanceCache factory = GeckoLibUtil.createInstanceCache(this);
+    protected boolean hasGoldBlock = false;
 
     public StarbuncleWheelTile(BlockPos pos, BlockState state) {
         super(ModBlockRegistry.STARBY_TILE.get(), pos, state);
-        setLazyTickRate(20);
+    }
+
+    public void findGoldBlock() {
+        Direction direction = getBlockState().getValue(StarbuncleWheelBlock.FACING);
+        hasGoldBlock = direction != Direction.UP && direction != Direction.DOWN && level != null &&
+                level.getBlockState(getBlockPos().relative(direction.getClockWise())).is(Tags.Blocks.STORAGE_BLOCKS_GOLD);
     }
 
     @Override
     public float getGeneratedSpeed() {
-        int spd = CreoConfig.WHEEL_BASE_SPEED.get();
-        Direction direction = getBlockState().getValue(StarbuncleWheelBlock.FACING);
-        if(direction != Direction.UP && direction != Direction.DOWN) {
-            if (level.getBlockState(getBlockPos().relative(direction.getClockWise())).is(Tags.Blocks.STORAGE_BLOCKS_GOLD)) {
-                spd = CreoConfig.WHEEL_BONUS_SPEED.get();
-            }
-        }
-
-        return convertToDirection(spd, getBlockState().getValue(HandCrankBlock.FACING));
+        int speed = hasGoldBlock ? CreoConfig.WHEEL_BONUS_SPEED.get() : CreoConfig.WHEEL_BASE_SPEED.get();
+        return convertToDirection(speed, getBlockState().getValue(StarbuncleWheelBlock.FACING));
     }
 
     @Override
-    public void lazyTick() {
-        super.lazyTick();
-        ModBlockRegistry.STARBY_WHEEL.get().updateAllSides(getBlockState(), level, worldPosition);
+    public void onLoad() {
+        super.onLoad();
+        findGoldBlock();
+        updateGeneratedRotation();
     }
 
     @Override
@@ -50,7 +50,7 @@ public class StarbuncleWheelTile extends GeneratingKineticBlockEntity implements
             return PlayState.CONTINUE;
         }));
     }
-    AnimatableInstanceCache factory = GeckoLibUtil.createInstanceCache(this);
+
     @Override
     public AnimatableInstanceCache getAnimatableInstanceCache() {
         return factory;

--- a/src/main/java/com/hollingsworth/ars_creo/common/registry/ModBlockRegistry.java
+++ b/src/main/java/com/hollingsworth/ars_creo/common/registry/ModBlockRegistry.java
@@ -1,13 +1,11 @@
 package com.hollingsworth.ars_creo.common.registry;
 
 import com.hollingsworth.ars_creo.ArsCreo;
-import com.hollingsworth.ars_creo.client.render.StarbuncleWheelRenderer;
 import com.hollingsworth.ars_creo.common.block.StarbuncleWheelBlock;
 import com.hollingsworth.ars_creo.common.block.StarbuncleWheelTile;
 import com.hollingsworth.ars_creo.common.lib.LibBlock;
-import com.hollingsworth.arsnouveau.common.items.RendererBlockItem;
+import com.hollingsworth.arsnouveau.common.items.AnimBlockItem;
 import com.hollingsworth.arsnouveau.setup.registry.ItemsRegistry;
-import net.minecraft.client.renderer.BlockEntityWithoutLevelRenderer;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.world.item.Item;
@@ -17,27 +15,18 @@ import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.neoforged.neoforge.registries.DeferredHolder;
 import net.neoforged.neoforge.registries.DeferredRegister;
 
-import java.util.function.Supplier;
-
-
-
 public class ModBlockRegistry {
     public static final DeferredRegister<Block> BLOCK_REG = DeferredRegister.create(BuiltInRegistries.BLOCK, ArsCreo.MODID);
     public static final DeferredRegister<BlockEntityType<?>> BLOCK_ENTITY_REG = DeferredRegister.create(Registries.BLOCK_ENTITY_TYPE, ArsCreo.MODID);
 
     public static final DeferredRegister<Item> ITEMS = DeferredRegister.create(BuiltInRegistries.ITEM, ArsCreo.MODID);
     public static DeferredHolder<Block, StarbuncleWheelBlock> STARBY_WHEEL = BLOCK_REG.register(LibBlock.STARBUNCLE_WHEEL, () -> new StarbuncleWheelBlock(defaultProperties().noOcclusion().lightLevel((state) -> 10)));
+    @SuppressWarnings("all")
     public static DeferredHolder<BlockEntityType<?>, BlockEntityType<StarbuncleWheelTile>> STARBY_TILE = BLOCK_ENTITY_REG.register(LibBlock.STARBUNCLE_WHEEL, () -> BlockEntityType.Builder.of(StarbuncleWheelTile::new, STARBY_WHEEL.get()).build(null));
     public static DeferredHolder<Item, Item> STARBY_WHEEL_ITEM;
 
     public static void onBlockItemsRegistry() {
-        STARBY_WHEEL_ITEM = ITEMS.register(LibBlock.STARBUNCLE_WHEEL, () -> new RendererBlockItem(ModBlockRegistry.STARBY_WHEEL.get(), ItemsRegistry.defaultItemProperties()) {
-            @Override
-            public Supplier<BlockEntityWithoutLevelRenderer> getRenderer() {
-                return StarbuncleWheelRenderer::getISTER;
-            }
-        });
-
+        STARBY_WHEEL_ITEM = ITEMS.register(LibBlock.STARBUNCLE_WHEEL, () -> new AnimBlockItem(ModBlockRegistry.STARBY_WHEEL.get(), ItemsRegistry.defaultItemProperties()));
     }
 
     public static Block.Properties defaultProperties(){


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
<!-- Example: Added a new spell effect that allows players to teleport short distances -->
Starbuncle wheels now only check for goldblock when updated
Starbuncle wheel items now don't rotate, instead of rotating inconsistently

## Reason for Change

<!-- Why is this change needed? What problem does it solve? -->
<!-- Example: Players wanted a way to quickly travel without using elytra -->
Optimization
Bug fix

## Related Issues

<!-- Link any related issues using "Fixes #123" or "Closes #123" to auto-close them -->
<!-- Use "Related to #123" for issues that are related but not resolved by this PR -->

None Found

## Type of Change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] Refactor (no functional changes expected)

## Manual Testing Performed

<!-- Describe the tests you ran to verify your changes -->

- [x] Tested in single-player
- [ ] Tested in multiplayer (LAN)
- [ ] Tested in multiplayer (server)

## Checklist

- [x] I have tested my changes thoroughly
- [x] I have updated documentation if needed
